### PR TITLE
更新 GitHub Actions (CI) 依赖性版本

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,21 +11,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
 
       - name: Setup Typst
-        uses: yusancky/setup-typst@v2.0.1
-        id: setup-typst
+        uses: typst-community/setup-typst@v4
         with:
-          version: 'latest'
+          typst-version: 'latest'
 
       - run: typst compile cv.typ --font-path ./src/fonts
       - run: typst compile letter.typ --font-path ./src/fonts
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: ./*.pdf


### PR DESCRIPTION
### 更新基础操作

更新 Checkout 操作和 Upload Artifact 操作至 v4。

> [!IMPORTANT] 
> Upload Artifact V3 已完全弃用。不进行更新则无法通过 CI 自动构建 PDF。

### 更新 Setup Typst

更新 [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) 至 v4
。

> [!IMPORTANT] 
> 操作 `yusancky/setup-typst` 已迁移至仓库 `typst-community/setup-typst`。前往 [公告](https://github.com/yusancky/setup-typst/blob/main/announcement_zh-Hans-CN.md) 查看更多信息。